### PR TITLE
fixing an issue with caps

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,8 +90,10 @@ async function main() {
         console.log('-----------------------')
         console.log()
         // get data from route53 about current zerotier records
+        console.log('Getting existing records from the DNS provider...')
         var recordList = await getRecords(process.env.hosted_zone)
         
+        console.log('Getting the list of member systems from Zerotier...')
         // get data from zerotier about current network members
         var memberList = await getZTMembers()
         

--- a/zerotier.js
+++ b/zerotier.js
@@ -13,7 +13,7 @@ module.exports.getZTMembers = function getZTMembers() {
         for (member of ztData.data) {
             var addme = {}
             if (member.name != "") {
-                addme.name = member.name
+                addme.name = member.name.toLowerCase()
             } else {
                 addme.name = member.nodeId
             }


### PR DESCRIPTION
 - added some comments for troubleshooting
 - added a `toLowerCase()` to the zerotier member name
 
The member name or short name in zerotier allows for mixed lowercase and caps. DNS records do not allow for caps. If there were a member name with a cap in it the script would detect a diff between the memberList and the recordList every time it checked for a diff. This fixes that issue. 